### PR TITLE
Update languages.js

### DIFF
--- a/components/languages.js
+++ b/components/languages.js
@@ -12,7 +12,7 @@ export const LANGUAGES = {
   it: 'Italian',
   lt: 'Lithuanian',
   no: 'Norwegian',
-  br: 'Portuguese',
+  pt: 'Portuguese',
   ro: 'Romanian',
   ru: 'Russian',
   es: 'Spanish',


### PR DESCRIPTION
The language code for Portuguese is PT, as the language originated in Portugal.